### PR TITLE
Update to sumo 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3
 
-ENV SUMO_VERSION 0.25.0
+ENV SUMO_VERSION 1.3.1
 ENV SUMO_SRC sumo-src-$SUMO_VERSION
 ENV SUMO_HOME /opt/sumo
 
@@ -8,19 +8,26 @@ ENV SUMO_HOME /opt/sumo
 RUN apt-get update && apt-get install -qq \
     wget \
     g++ \
-    make \
+    cmake \
     libxerces-c3.1 \
-    libxerces-c3-dev \
+    libxerces-c-dev \
+    libgdal-dev \
+    libproj-dev \
+    libfox-1.6-dev\
+    libgl2ps-dev\ 
+    swig\
     python
 
 # Download and extract source code
-RUN wget http://downloads.sourceforge.net/project/sumo/sumo/version%20$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz
+RUN wget https://sumo.dlr.de/releases/$SUMO_VERSION/sumo-src-$SUMO_VERSION.tar.gz
 RUN tar xzf sumo-src-$SUMO_VERSION.tar.gz && \
     mv sumo-$SUMO_VERSION $SUMO_HOME && \
     rm sumo-src-$SUMO_VERSION.tar.gz
 
 # Configure and build from source.
-RUN cd $SUMO_HOME && ./configure && make install
+RUN cd $SUMO_HOME && mkdir build/cmake-build && \ 
+    cd build/cmake-build && cmake ../.. && make -j $(nproc) && \
+    make install
 
 # Ensure the installation works. If this call fails, the whole build will fail.
 RUN sumo
@@ -41,4 +48,3 @@ EXPOSE 1234
 ENTRYPOINT ["sumo"]
 
 CMD ["--help"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN sumo
 RUN apt-get install -qq -y ssh-client git
 RUN mkdir -p /opt/traci4j 
 WORKDIR /opt/traci4j
-RUN git clone https://github.com/egueli/TraCI4J.git /opt/traci4j && mvn package -Dmaven.test.skip=true
+RUN git clone https://github.com/egueli/TraCI4J.git /opt/traci4j
+RUN mvn package -f pom.xml -Dmaven.test.skip=true -Dmaven.compiler.source=1.6 -Dmaven.compiler.target=1.6
 
 # Add volume to allow for host data to be used
 RUN mkdir /data


### PR DESCRIPTION
## changes

- Update sumo version
- change make process to use cmake as per build instructions https://sumo.dlr.de/docs/Installing/Linux_Build.html
- force maven to use a supported source and target version (egueli/TraCI4J#33)

## testing
build the image

`docker build -t sumo_image .`
check it worked by getting the version of sumo in the docker

```bash
docker run -ti sumo_image --version
Eclipse SUMO Version 1.3.1
 Build features: Linux-4.15.0-66-generic x86_64 GNU 6.3.0 Release Proj GUI GDAL GL2PS SWIG
 Copyright (C) 2001-2019 German Aerospace Center (DLR) and others; https://sumo.dlr.de

Eclipse SUMO Version 1.3.1 is part of SUMO.
This program and the accompanying materials
are made available under the terms of the Eclipse Public License v2.0
which accompanies this distribution, and is available at
http://www.eclipse.org/legal/epl-v20.html
SPDX-License-Identifier: EPL-2.0
```

there should be sumo 1.3.1 in container